### PR TITLE
More informative message presented longer

### DIFF
--- a/Kernel/Routines/ZSY.m
+++ b/Kernel/Routines/ZSY.m
@@ -557,7 +557,7 @@ JOBVIEWZ ;
  ;
 JOBVIEWZ2(X) ; [Private] View Job Information
  I X'?1.N W !,"Not a valid job number." Q
- I '$zgetjpi(X,"isprocalive") W !,"This process does not exist" Q
+ I '$zgetjpi(X,"isprocalive") N P W !,"This process ("_X_") does not exist" R *P:3 Q
  ;
  N EXAMREAD
  N DONEONE S DONEONE=0


### PR DESCRIPTION
Previously, the message did NOT include the $JOB value of the process when it wasn't active,
nor did it show the message for longer than a flash of time.  I changed code to use a read *P with a 
timeout, so message could be dismissed with a key-press, but would be visible for three seconds, which
should be enough to make it readable. 
I don't signify that it is waiting on a key-press visually. I don't know if "://" should be on the end of the text
to tell a VistA person that it can be dismissed with a carriage return.  Likewise, I don't know if *P is better or a
carriage return requiring P is better.
Thoughts?