### PR TITLE
Fix type refersh-> refresh with longer timeout

### DIFF
--- a/Kernel/Routines/ZSY.m
+++ b/Kernel/Routines/ZSY.m
@@ -557,7 +557,7 @@ JOBVIEWZ ;
  ;
 JOBVIEWZ2(X) ; [Private] View Job Information
  I X'?1.N W !,"Not a valid job number." Q
- I '$zgetjpi(X,"isprocalive") N P W !,"This process ("_X_") does not exist" R *P:3 Q
+ I '$zgetjpi(X,"isprocalive") N P W !,"This process ("_X_") does not exist" R *P:$G(DTIME,3) Q
  ;
  N EXAMREAD
  N DONEONE S DONEONE=0
@@ -565,7 +565,7 @@ JOBVIEWZ2(X) ; [Private] View Job Information
  . N % S %=$$EXAMINEJOBBYPID(X)
  . I %'=0 W !,"The job didn't respond to examination for 305 ms. You may try again." S DONEONE=1 QUIT
  . D PRINTEXAMDATA(X,$G(EXAMREAD))
- . W "Enter to Refersh, V for variables, I for ISVs, K to kill",!
+ . W "Enter to Refresh, V for variables, I for ISVs, K to kill",!
  . W "L to load variables into your ST and quit, ^ to go back: ",!
  . W "D to debug (broken), Z to zshow all data for debugging."
  . R EXAMREAD:$G(DTIME,300)


### PR DESCRIPTION
Currently, there is a typo where refersh is written instead of refresh.
Also the message re "This process does not exist"  only is presented for 3 seconds (which was too short to notice)
The code uses a READ with timeout, the timeout was just too short.
I changed the code to use the DTIME variable if it exists.
If it doesn't, 3 seconds seems too short, but I didin't know what else to use.